### PR TITLE
Added usage information, exit codes, error handling & quote escaping

### DIFF
--- a/Plist2ObjC.m
+++ b/Plist2ObjC.m
@@ -75,7 +75,7 @@ NSString *recursiveDump(id object, int level)
 
 void printUsage()
 {
-    printf("Usage: plist2objc [path to plist]\n\n");
+    printf("Usage: plist2objc <file.plist>\n\n");
 }
 
 int main(int argc, char *argv[])


### PR DESCRIPTION
I added usage information, so if the user does not provide a path to a
plist or provides more than on path they will receive an error message
and a exit code of 1.

I have also added a check to supplied file, if it is invalid than it
will return 1 and it will show an error.

I have also added quote detection to the NSString handler, if it
detects a quote in the string then it will escape it.

I have tested my change to the code.
